### PR TITLE
add configuration options to support AWS GovCloud region

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Create a copy of *config.sample.json* as *config.json* and then customise as app
 Name | Description | Required
 --- | --- | ---
 BUCKET | The S3 bucket name to use. This will form part of the URL shortener website address if you're not using a custom domain. | Y
+S3_PARTITION | The [S3 partition](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) to use. | Y
 REGION | The [AWS region](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) to deploy to. | Y
 STAGE | The [AWS stage](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html) to deploy to. | Y
+API_ENDPOINT_TYPE | The [API Gateway endpoint type](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-basic-concept.html) to use. | Y
 API_URL | The URL of the endpoint that forms should be sent to. This is only known after the first deployment, so leave empty for now. | Y
 
 ### Deploy API

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,6 +1,8 @@
 {
   "BUCKET": "",
+  "S3_PARTITION": "aws",
   "REGION": "eu-west-1",
   "STAGE": "dev",
+  "API_ENDPOINT_TYPE": "EDGE",
   "API_URL": ""
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,6 +2,7 @@ service: serverless-url-shortener
 
 provider:
   name: aws
+  endpointType: ${file(config.json):API_ENDPOINT_TYPE}
   runtime: nodejs6.10
   stage: ${file(config.json):STAGE}
   region: ${file(config.json):REGION}
@@ -9,7 +10,7 @@ provider:
     - Effect: Allow
       Action:
         - s3:PutObject
-      Resource: "arn:aws:s3:::${file(config.json):BUCKET}/*"
+      Resource: "arn:${file(config.json):S3_PARTITION}:s3:::${file(config.json):BUCKET}/*"
 
 functions:
   store:
@@ -39,5 +40,5 @@ resources:
             - s3:GetObject
             Effect: Allow
             Resource:
-            - arn:aws:s3:::${file(config.json):BUCKET}/*
+            - arn:${file(config.json):S3_PARTITION}:s3:::${file(config.json):BUCKET}/*
             Principal: "*"


### PR DESCRIPTION
The AWS GovCloud region (us-gov-west-1) requires a different S3 partition; whereas all the normal S3 regions use S3 ARNs starting with `arn:aws:s3`, the GovCloud region uses `arn:aws-us-gov:s3`. Likewise, API Gateway in the GovCloud region doesn't support edge-optimized endpoints, instead only supporting regional and private endpoints.